### PR TITLE
docs(deployment): add deploy as a service in swarm

### DIFF
--- a/docs/source/deployment.rst
+++ b/docs/source/deployment.rst
@@ -74,6 +74,17 @@ For example, when connecting to a remote Swarm node:
 
   $ docker run -d -p 9000:9000 portainer/portainer -H tcp://<REMOTE_HOST>:<REMOTE_PORT> --swarm
 
+If you're using swarm mode, you can also deploy it as a service in your cluster:
+
+.. code-block:: bash
+
+  $ docker service create \
+      --name portainer \
+      --publish 9000:9000 \
+      --constraint 'node.role == manager' \
+      --mount type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock \
+      portainer/portainer \
+      --swarm
 
 Connect to a Docker engine with TLS enabled
 ===========================================


### PR DESCRIPTION
I've added a new paragraph to launch Portainer as a service in the swarm cluster itself. It can be very useful.