### PR TITLE
Add docker registry account requirement

### DIFF
--- a/docs/source/contribute.rst
+++ b/docs/source/contribute.rst
@@ -11,6 +11,7 @@ Requirements
 ------------
 
 Ensure you have `Docker <https://docs.docker.com/engine/installation/>`_, `Node.js <https://nodejs.org/en/>`_ >= 0.8.4 and `npm <https://www.npmjs.com/>`_ installed locally.
+Create an account in `Docker's registry <https://cloud.docker.com/>`_ (if you don't have it yet) and log in using "docker login" command.
 
 Build
 -----


### PR DESCRIPTION
Docker cloud allows pulling images only for authorized users. It is required for pulling a [portainer/golang-builder](https://github.com/portainer/portainer/blob/develop/gruntfile.js#L420) image.