### PR TITLE
docs(templates): update volumes format

### DIFF
--- a/docs/source/templates.rst
+++ b/docs/source/templates.rst
@@ -150,9 +150,9 @@ Example:
 ``volumes``
 -----------
 
-A JSON array describing the associated volumes of the template. Each element in the array must be a valid JSON string.
+A JSON array describing the associated volumes of the template. Each element in the array must be a valid JSON object that has a required container property.
 
-For each element in the array, a Docker volume will be created and associated when starting the container.
+For each element in the array, a Docker volume will be created and associated when starting the container. If a bind property is defined it will be used as the source of a bind mount.
 
 This field is **optional**.
 

--- a/docs/source/templates.rst
+++ b/docs/source/templates.rst
@@ -161,7 +161,15 @@ Example:
 .. code-block:: json
 
   {
-    "volumes": ["/var/lib/mysql", "/var/log/mysql"]
+    "volumes": [
+      {
+        "container": "/etc/nginx"
+      },
+      {
+        "container": "/usr/share/nginx/html",
+        "bind": "/var/www"
+      }
+    ]
   }
 
 ``ports``


### PR DESCRIPTION
I added documentation for the volume format changes from https://github.com/portainer/portainer/pull/1154. Is this clear enough?