### PR TITLE
Remove linux 386 from supported platforms list

### DIFF
--- a/docs/source/limitations.rst
+++ b/docs/source/limitations.rst
@@ -34,7 +34,6 @@ Supported platforms
 Portainer can be deployed on the following platforms:
 
 * Linux amd64
-* Linux 386
 * Linux arm
 * Linux arm64
 * Linux ppc64le


### PR DESCRIPTION
portainer/portainer#1280
https://github.com/portainer/portainer/commit/587e2fa673416201917d19b09db40aa31de874ac#diff-0b83f9dedf40d7356e5ca147a077acb4