### PR TITLE
upload alternative nginx proxy configuration

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -41,6 +41,26 @@ Here is a working configuration for Nginx (tested on 1.11) to serve Portainer at
 
 Replace ``ADDRESS:PORT`` with the Portainer server/container details.
 
+Alternative nginx configuration (tested on v.1.13.7)
+
+.. code-block:: nginx-1-13-7
+
+  rewrite ^/portainer$ /portainer/ redirect;
+
+  location ~ ^/portainer/(.*)$ {
+    proxy_pass              http://portainer/$1;
+    proxy_redirect          off;
+    proxy_set_header        Host            $host;
+    proxy_set_header        X-Real-IP       $remote_addr;
+    proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+    client_max_body_size    10m;
+    client_body_buffer_size 128k;
+    proxy_connect_timeout   90;
+    proxy_send_timeout      90;
+    proxy_read_timeout      90;
+    proxy_buffers           32 4k;
+  }
+
 How can I configure my reverse proxy to serve Portainer using HAProxy?
 ======================================================================
 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -43,7 +43,7 @@ Replace ``ADDRESS:PORT`` with the Portainer server/container details.
 
 Alternative nginx configuration (tested on v.1.13.7)
 
-.. code-block:: nginx-1-13-7
+.. code-block:: nginx
 
   upstream portainer {
       server ADDRESS:PORT;

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -45,21 +45,29 @@ Alternative nginx configuration (tested on v.1.13.7)
 
 .. code-block:: nginx-1-13-7
 
-  rewrite ^/portainer$ /portainer/ redirect;
-
-  location ~ ^/portainer/(.*)$ {
-    proxy_pass              http://portainer/$1;
-    proxy_redirect          off;
-    proxy_set_header        Host            $host;
-    proxy_set_header        X-Real-IP       $remote_addr;
-    proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-    client_max_body_size    10m;
-    client_body_buffer_size 128k;
-    proxy_connect_timeout   90;
-    proxy_send_timeout      90;
-    proxy_read_timeout      90;
-    proxy_buffers           32 4k;
+  upstream portainer {
+      server ADDRESS:PORT;
   }
+
+  server {
+    listen 80;
+
+    rewrite ^/portainer$ /portainer/ redirect;
+
+    location ~ ^/portainer/(.*)$ {
+      proxy_pass              http://portainer/$1;
+      proxy_redirect          off;
+      proxy_set_header        Host            $host;
+      proxy_set_header        X-Real-IP       $remote_addr;
+      proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+      client_max_body_size    10m;
+      client_body_buffer_size 128k;
+      proxy_connect_timeout   90;
+      proxy_send_timeout      90;
+      proxy_read_timeout      90;
+      proxy_buffers           32 4k;
+    }
+}
 
 How can I configure my reverse proxy to serve Portainer using HAProxy?
 ======================================================================

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -67,7 +67,7 @@ Alternative nginx configuration (tested on v.1.13.7)
       proxy_read_timeout      90;
       proxy_buffers           32 4k;
     }
-}
+  }
 
 How can I configure my reverse proxy to serve Portainer using HAProxy?
 ======================================================================


### PR DESCRIPTION
Some users has experience to error: `404 page not found`.

1. FIX: the path redirection from /path to -> /path/
2. FIX: the proxy configuration for better performance
