### PR TITLE
docs(templates): document readonly option in volume definition

### DIFF
--- a/docs/source/templates.rst
+++ b/docs/source/templates.rst
@@ -168,7 +168,9 @@ Example:
 
 A JSON array describing the associated volumes of the template. Each element in the array must be a valid JSON object that has a required container property.
 
-For each element in the array, a Docker volume will be created and associated when starting the container. If a bind property is defined it will be used as the source of a bind mount.
+For each element in the array, a Docker volume will be created and associated when starting the container.
+If a bind property is defined it will be used as the source of a bind mount.
+If a readonly property is is defined and true, the volume will be mounted in read-only mode.
 
 This field is **optional**.
 
@@ -183,7 +185,8 @@ Example:
       },
       {
         "container": "/usr/share/nginx/html",
-        "bind": "/var/www"
+        "bind": "/var/www",
+        "readonly": true
       }
     ]
   }


### PR DESCRIPTION
It looks like this was introduced with portainer/portainer#1154 but didn't make the docs.

Only documented this in the container format and not the stack format,
since the readonly flag is not supported for services according to Docker documentation:
"Important: When using bind mounts with services, selinux labels (:Z and :z),
as well as :ro are ignored. See moby/moby #32579 for details."
(https://docs.docker.com/storage/bind-mounts/#configure-the-selinux-label)