### PR TITLE
Fix yaml errors in stack agent

### DIFF
--- a/docs/source/agent.rst
+++ b/docs/source/agent.rst
@@ -119,8 +119,8 @@ Alternatively, you can deploy the agent using the following stack:
         - portainer_agent
       deploy:
         mode: global
-      placement:
-        constraints: [node.platform.os == linux]
+        placement:
+          constraints: [node.platform.os == linux]
 
   networks:
     portainer_agent:


### PR DESCRIPTION
The  parameter PLACEMENT should be in deploy parameter .See more: <https://docs.docker.com/compose/compose-file/#placement>