### PR TITLE
fix(contribute): fix wrong ln path

### DIFF
--- a/docs/source/contribute.rst
+++ b/docs/source/contribute.rst
@@ -21,7 +21,7 @@ Checkout the project, set up the project inside your ``$GOPATH`` and go inside t
 
   $ git clone https://github.com/portainer/portainer.git
   $ mkdir -p ${GOPATH}/src/github.com/portainer
-  $ ln -s ${PWD}/portainer/api ${GOPATH}/src/github.com/portainer/portainer
+  $ ln -s ${PWD}/portainer ${GOPATH}/src/github.com/portainer/portainer
   $ cd portainer
 
 Install dependencies with yarn:


### PR DESCRIPTION
I just clone the portainer project, and when running `yarn start`, the grunt file failed due of a wrong symbolic link. Here the correct symbolic path to make it works correctly.