### PR TITLE
Add support for working inside a Docker Container with VS Code

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,43 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or the definition README at
+// https://github.com/microsoft/vscode-dev-containers/tree/master/containers/docker-existing-dockerfile
+{
+	"name": "Existing Dockerfile",
+
+	// Sets the run context to one level up instead of the .devcontainer folder.
+	"context": "..",
+
+	// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
+	"dockerFile": "../Dockerfile",
+
+	// The optional 'runArgs' property can be used to specify additional runtime arguments.
+	"runArgs": [
+		// Uncomment the next line to use Docker from inside the container. See https://aka.ms/vscode-remote/samples/docker-in-docker for details.
+		// "-v","/var/run/docker.sock:/var/run/docker.sock",
+
+		// Uncomment the next line if you will be using a ptrace-based debugger like C++, Go, and Rust.
+		// "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"
+
+		// You may want to add a non-root user to your Dockerfile. On Linux, this will prevent
+		// new files getting created as root. See https://aka.ms/vscode-remote/containers/non-root-user
+		// for the needed Dockerfile updates and then uncomment the next line.
+		// "-u", "vscode"
+	],
+
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		// This will ignore your local shell user setting for Linux since shells like zsh are typically 
+		// not in base container images. You can also update this to an specific shell to ensure VS Code 
+		// uses the right one for terminals and tasks. For example, /bin/bash (or /bin/ash for Alpine).
+		"terminal.integrated.shell.linux": null
+	},
+
+	// Uncomment the next line if you want to publish any ports.
+	// "appPort": [],
+
+	// Uncomment the next line to run commands after the container is created - for example installing git.
+	"postCreateCommand": "apk update && apk add git",
+
+	// Add the IDs of extensions you want installed when the container is created in the array below.
+	"extensions": ["ms-python.python", "lextudio.restructuredtext"]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,13 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Make HTML",
+            "type": "shell",
+            "command": "make html",
+            "options": {"cwd": "${workspaceRoot}/docs"}
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -29,3 +29,4 @@ into the running container and finally open a terminal for you inside it.
 
 Inside the devcontainer based project workspace you can then run the
 pre-defined VS Code Task "Make HTML" to build the documentation.
+Refer to [this link](https://code.visualstudio.com/docs/getstarted/tips-and-tricks#_run-tasks-from-the-terminal-menu) on how to run tasks in VS Code.

--- a/README.md
+++ b/README.md
@@ -14,3 +14,18 @@ $ docker run --rm -v ${PWD}/docs:/src portainer/docbuilder:latest make html
 ```
 
 HTML files will be available under `docs/build/html` for preview.
+
+## Visual Studio Code
+
+You can also work directly inside the docker container used above via
+[VS Code devcontainer](https://code.visualstudio.com/docs/remote/containers).
+
+Please follow the getting started guide from the link above to install and
+setup the required VS Code extensions. Once they are ready VS Code will
+inform you that it has detected a devcontainer configuration and you can
+switch your project folder into it. During startup of the devcontainer
+VS Code will build the Dockerfile of this repository, mount the project
+into the running container and finally open a terminal for you inside it.
+
+Inside the devcontainer based project workspace you can then run the
+pre-defined VS Code Task "Make HTML" to build the documentation.


### PR DESCRIPTION
This makes it possible to work with the documentation directly inside the Docker Container which is then used to build the HTML site.