### PR TITLE
correct windows paths so slashes appear correctly on screen

### DIFF
--- a/docs/source/deployment.rst
+++ b/docs/source/deployment.rst
@@ -35,7 +35,7 @@ instance to a manually deployed Portainer agent.
 Persist Portainer data
 ======================
 
-By default, Portainer store its data inside the container in the ``/data`` folder on Linux (``C:\\data`` on Windows).
+By default, Portainer store its data inside the container in the ``/data`` folder on Linux (``C:\data`` on native Windows containers; see more below).
 
 You'll need to persist Portainer data to keep your changes after restart/upgrade of the Portainer container. You can use a bind mount on Linux to persist the data on the Docker host folder:
 
@@ -45,12 +45,11 @@ You'll need to persist Portainer data to keep your changes after restart/upgrade
 
 Windows
 ----------------------------------------------------------
-Docker for Windows 10 supports running both Linux and Windows containers and you need to use a different start command depending on which container type you are using.
-Windows Server supports only native Windows containers.
+Docker for Windows 10 supports running both Linux and Windows containers and you need to use a different start command depending on which container type you are using. Windows Server supports only native Windows containers.
 
-**Note:** You must create the folder in which you want the data to be persisted before running the following command. For example, if you want the data to persist in C:\ProgramData\Portainer you need to create the Portainer directory within C:\ProgramData as it does not exist by default.
+**Note:** You must create the folder in which you want the data to be persisted before running the following command. For example, if you want the data to persist in C:\\ProgramData\\Portainer you need to create the Portainer directory within C:\\ProgramData as it does not exist by default.
 
-Example for Linux containers:
+Example for Linux containers on Windows:
 
 ::
 


### PR DESCRIPTION
There are references here to Windows path using normal path separators (\\), but in markdown those must be escaped (when not preformatted text), otherwise they do not appear on screen. That was the case with a few of the references here. 

And note that one CANNOT do a global find/replace, because again the references in preformatted text should NOT be escaped (and there was in fact one reference with an escaped path separator, where it should not have been).

I also made a couple of other minor changes to clarify references to native Windows containers (to distinguish them from linux containers running on Windows).