### PR TITLE
Fix broken link

### DIFF
--- a/docs/v2.0/deploy/linux.md
+++ b/docs/v2.0/deploy/linux.md
@@ -73,7 +73,7 @@ Portainer is comprised of two elements, the Portainer Server, and the Portainer 
 
 Note that the recommended deployment mode when using Swarm is using the Portainer Agent.
 
-To see the requeriments, please, visit the page of [requirements](/v2.0/deploy/requeriments.md)
+To see the requeriments, please, visit the page of [requirements](/v2.0/deploy/requirements.md)
 
 ### Docker Standalone
 


### PR DESCRIPTION
Typo in link: `/v2.0/deploy/requeriments.md` -> `/v2.0/deploy/requirements.md`