### PR TITLE
Incorrect word used and punctuation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ For information about contributing to the Portainer documentation, see [Contribu
 
 Portainer Community Edition 2.0 is the foundation of the Portainer world. With over half a million regular users, it’s a powerful, open-source toolset that allows you to easily build and manage containers in Docker, Swarm, Kubernetes and Azure ACI.
 
-Portainer works by hiding the complexity that makes managing contains hard behind an easy to use GUI. By negating the need for users to use CLI, write YAML or understand manifests, Portainer makes deploying apps and troubleshooting problems so simple, anyone can do it.
+Portainer works by hiding the complexity that makes managing containers hard, behind an easy to use GUI. By negating the need for users to use CLI, write YAML or understand manifests, Portainer makes deploying apps and troubleshooting problems so simple, anyone can do it.
 
 The Portainer development team is here to assist you on your container journey; you can engage with them any time through our community-based support channels.
 

--- a/docs/v2.0/deploy/linux.md
+++ b/docs/v2.0/deploy/linux.md
@@ -73,7 +73,7 @@ Portainer is comprised of two elements, the Portainer Server, and the Portainer 
 
 Note that the recommended deployment mode when using Swarm is using the Portainer Agent.
 
-By default, Portainer will expose the UI over the port 9000 and expose a TCP tunnel server over the port 8000. The latest is optional and is only required if you plan to use the Edge compute features with Edge agents.
+By default, Portainer will expose the UI over the port 9000 and expose a TCP tunnel server over the port 8000. The latter is optional and is only required if you plan to use the Edge compute features with Edge agents.
 
 To see the requirements, please, visit the page of [requirements](/v2.0/deploy/requirements).
 


### PR DESCRIPTION
Main page docs use "contain" when it should be "container". Minor punctuation in the same sentence for flow.