### PR TITLE
Adding linux for installation instruction page

### DIFF
--- a/start/install/server/docker/README.md
+++ b/start/install/server/docker/README.md
@@ -2,6 +2,8 @@
 
 Installation instructions can differ between platforms. Please choose your platform below:
 
+{% page-ref page="linux.md" %}
+
 {% page-ref page="wsl.md" %}
 
 {% page-ref page="wcs.md" %}


### PR DESCRIPTION
missing the linux page, I added it as it is confusing when reading the documentation.