### PR TITLE
Update build.txt - Code text without prompt ($)

### DIFF
--- a/advanced/app-templates/build.md
+++ b/advanced/app-templates/build.md
@@ -5,11 +5,11 @@ The best way to do this is to [bind-mount your own template file](../cli.md#use-
 First, clone the [Portainer templates repository](https://github.com/portainer/templates), edit the templates file, then build and run the container:
 
 ```text
-$ git clone https://github.com/portainer/templates.git portainer-templates
-$ cd portainer-templates
+git clone https://github.com/portainer/templates.git portainer-templates
+cd portainer-templates
 # Edit the file templates.json
-$ docker build -t portainer-templates .
-$ docker run -d -p "8080:80" portainer-templates
+docker build -t portainer-templates .
+docker run -d -p "8080:80" portainer-templates
 ```
 
 Access your template definitions at `http://docker-host:8080/templates.json`.
@@ -17,7 +17,7 @@ Access your template definitions at `http://docker-host:8080/templates.json`.
 You can also mount the `templates.json` file inside the container, so you can edit the file and see live changes:
 
 ```text
-$ docker run -d -p "8080:80" -v "${PWD}/templates.json:/usr/share/nginx/html/templates.json" portainer-templates
+docker run -d -p "8080:80" -v "${PWD}/templates.json:/usr/share/nginx/html/templates.json" portainer-templates
 ```
 
 For more information about the format of the app template, go [here](format.md).


### PR DESCRIPTION
When copying is needed to delete the $ symbol (prompt).