### PR TITLE
Add scope info to token

### DIFF
--- a/admin/registries/add/gitlab.md
+++ b/admin/registries/add/gitlab.md
@@ -6,11 +6,11 @@ From the menu select **Registries** then click **Add registry** and select **Git
 
 Complete the form, using the table below as a guide.
 
-| Field/Option                   | Overview                                                                              |
-| ------------------------------ | ------------------------------------------------------------------------------------- |
-| Username                       | Enter the username you use to log into your Gitlab registry.                          |
-| Personal Access Token          | Enter the personal access token that corresponds to the username above.               |
-| Override default configuration | If you need to make changes to the Portainer defaults for Gitlab, you can do so here. |
+| Field/Option                   | Overview                                                                                   |
+| ------------------------------ | ------------------------------------------------------------------------------------------ |
+| Username                       | Enter the username you use to log into your Gitlab registry.                               |
+| Personal Access Token          | Enter the personal access token (scope: `read_api`) that corresponds to the username above. |
+| Override default configuration | If you need to make changes to the Portainer defaults for Gitlab, you can do so here.      |
 
 {% hint style="info" %}
 For more information about creating a personal access token, see [Gitlab's own documentation](https://docs.gitlab.com/ee/user/profile/personal\_access\_tokens.html).

--- a/admin/registries/add/gitlab.md
+++ b/admin/registries/add/gitlab.md
@@ -9,7 +9,7 @@ Complete the form, using the table below as a guide.
 | Field/Option                   | Overview                                                                                   |
 | ------------------------------ | ------------------------------------------------------------------------------------------ |
 | Username                       | Enter the username you use to log into your Gitlab registry.                               |
-| Personal Access Token          | Enter the personal access token (scope: `read_api`) that corresponds to the username above. |
+| Personal Access Token          | Enter the personal access token that corresponds to the username above. Your personal access token will need the `read_api` and `read_registry` scopes assigned. |
 | Override default configuration | If you need to make changes to the Portainer defaults for Gitlab, you can do so here.      |
 
 {% hint style="info" %}


### PR DESCRIPTION
While trying to retrieve the projects from Gitlab with my initial guessed scope `read_registry` I got the "Unable to retrieve projects" failure msg until I set the scope to `read_api` to get the projects, too.