### PR TITLE
Create secret in correct namespace

### DIFF
--- a/advanced/ssl.md
+++ b/advanced/ssl.md
@@ -85,7 +85,7 @@ kubectl create namespace portainer
 Next, create a TLS secret containing the full certificate chain and matching private key:
 
 ```
-kubectl create secret tls portainer-tls-secret \
+kubectl create secret tls portainer-tls-secret -n portainer \
     --cert=/path/to/cert/file \
     --key=/path/to/key/file
 ```


### PR DESCRIPTION
I think `-n portainer` is missing here. Otherwise the helm installation (into the `portainer` namespace) cannot see the secret at all.

I am getting an error with the pod not starting when I follow these (and [these](https://docs.portainer.io/v/ce-2.6/start/install/server/kubernetes/baremetal)) instructions:

```
  Type     Reason       Age               From               Message
  ----     ------       ----              ----               -------
  Normal   Scheduled    34s               default-scheduler  Successfully assigned portainer/portainer-bdb69667f-qlc4g to uzuf52
  Warning  FailedMount  3s (x7 over 34s)  kubelet            MountVolume.SetUp failed for volume "certs" : secret "tls-secret" not found
```