### PR TITLE
Removed the 2.9.3 version code

### DIFF
--- a/start/install/server/docker/linux.md
+++ b/start/install/server/docker/linux.md
@@ -36,7 +36,7 @@ docker run -d -p 8000:8000 -p 9443:9443 --name portainer \
     --restart=always \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v portainer_data:/data \
-    cr.portainer.io/portainer/portainer-ce:2.9.3
+    cr.portainer.io/portainer/portainer-ce
 ```
 
 {% hint style="info" %}
@@ -54,7 +54,7 @@ Portainer Server has now been installed. You can check to see whether the Portai
 ```bash
 root@server:~# docker ps
 CONTAINER ID   IMAGE                          COMMAND                  CREATED       STATUS      PORTS                                                                                  NAMES             
-de5b28eb2fa9   portainer/portainer-ce:2.9.3   "/portainer"             2 weeks ago   Up 9 days   0.0.0.0:8000->8000/tcp, :::8000->8000/tcp, 0.0.0.0:9443->9443/tcp, :::9443->9443/tcp   portainer
+de5b28eb2fa9   portainer/portainer-ce         "/portainer"             2 weeks ago   Up 9 days   0.0.0.0:8000->8000/tcp, :::8000->8000/tcp, 0.0.0.0:9443->9443/tcp, :::9443->9443/tcp   portainer
 ```
 
 ## Logging In


### PR DESCRIPTION
Removed the :2.9.3 version code when setting up portainer in docker. This is an outdated version. 2.11.0 is the newest version.
