### PR TITLE
Fix open bugs link

### DIFF
--- a/contribute/contribute.md
+++ b/contribute/contribute.md
@@ -2,7 +2,7 @@
 
 ## Reporting bugs
 
-If you find a bug, please tell us so we can triage it. All bugs are managed in this [GitHub repo](https://github.com/portainer/portainer/issues/new?assignees=\&labels=bug%2Fneed-confirmation%2C+kind%2Fbug\&template=Bug\_report.md\&title=). When you click through, our template makes it easy to record all of the details. Before you report a bug, please check our list of [open bugs](https://github.com/portainer/portainer/labels/kind%2bug) in case someone else has already reported it.
+If you find a bug, please tell us so we can triage it. All bugs are managed in this [GitHub repo](https://github.com/portainer/portainer/issues/new?assignees=\&labels=bug%2Fneed-confirmation%2C+kind%2Fbug\&template=Bug\_report.md\&title=). When you click through, our template makes it easy to record all of the details. Before you report a bug, please check our list of [open bugs](https://github.com/portainer/portainer/labels/kind%2Fbug) in case someone else has already reported it.
 
 Go [here](../faq/contributing/how-do-you-decide-which-bugs-and-features-to-work-on-first.md) to learn how we prioritize bug fixes.
 


### PR DESCRIPTION
The open bugs link was broken and linking to  a search for
`is:open label:kind+ug` rather than `is:open label:kind/bug`.