### PR TITLE
Fix environment variable examples

### DIFF
--- a/user/docker/stacks/add.md
+++ b/user/docker/stacks/add.md
@@ -31,7 +31,7 @@ Environment variables can be set individually within Portainer or you can use **
 
 ```
 environment:
-  - MY_ENVIRONMENT_VARIABLE: ${MY_ENVIRONMENT_VARIABLE}
+  MY_ENVIRONMENT_VARIABLE: ${MY_ENVIRONMENT_VARIABLE}
 ```
 
 Alternatively, on Docker Standalone environments you can add `stack.env` as an `env_file` definition to add all the environment variables that you have defined individually as well as those included in an uploaded .env file:
@@ -69,7 +69,7 @@ Environment variables can be set individually within Portainer or you can use **
 
 ```
 environment:
-  - MY_ENVIRONMENT_VARIABLE: ${MY_ENVIRONMENT_VARIABLE}
+  MY_ENVIRONMENT_VARIABLE: ${MY_ENVIRONMENT_VARIABLE}
 ```
 
 Alternatively, you can add `stack.env` as an `env_file` definition to add all the environment variables that you have defined individually as well as those included in an uploaded .env file:
@@ -146,7 +146,7 @@ Environment variables can be set individually within Portainer or you can use **
 
 ```
 environment:
-  - MY_ENVIRONMENT_VARIABLE: ${MY_ENVIRONMENT_VARIABLE}
+  MY_ENVIRONMENT_VARIABLE: ${MY_ENVIRONMENT_VARIABLE}
 ```
 
 Alternatively, you can add `stack.env` as an `env_file` definition to add all the environment variables that you have defined individually as well as those included in an uploaded .env file:


### PR DESCRIPTION
In a YAML compose file, a set of environment variables can be represented as a sequence or a mapping, so either of these are valid:

```
# As a sequence (each line is a string)
environment:
  - MY_ENVIRONMENT_VARIABLE=${MY_ENVIRONMENT_VARIABLE}
```
```
# As a mapping (each line is a key/value pair)
environment:
  MY_ENVIRONMENT_VARIABLE: ${MY_ENVIRONMENT_VARIABLE}
```
The previous examples use a dash to indicate an element of a sequence but then use a colon between the variable and its definition, which isn't valid YAML. (If you try to use the example verbatim, you get the error `services.foo.environment.0 must be a string`, ask me how I know. :P)