### PR TITLE
docs: nginx-proxy now owned by nginxproxy

### DIFF
--- a/advanced/reverse-proxy/nginx.md
+++ b/advanced/reverse-proxy/nginx.md
@@ -5,7 +5,7 @@
 To deploy Portainer behind an nginx proxy in a Docker standalone scenario you must use a Docker Compose file. In the following docker-compose.yml you will find the configuration of the nginx proxy and the Portainer Server.
 
 {% hint style="info" %}
-This example uses the excellent [jwilder/nginx-proxy](https://hub.docker.com/r/jwilder/nginx-proxy) image as the proxy container, which requires no additional configuration beyond the two environment variables added to the `portainer` container's definition.
+This example uses the excellent [nginxproxy/nginx-proxy](https://hub.docker.com/r/nginxproxy/nginx-proxy) image as the proxy container, which requires no additional configuration beyond the two environment variables added to the `portainer` container's definition.
 {% endhint %}
 
 {% tabs %}
@@ -15,7 +15,7 @@ version: "2"
 
 services:
   nginx-proxy:
-    image: jwilder/nginx-proxy
+    image: nginxproxy/nginx-proxy
     restart: always
     ports:
       - "80:80"
@@ -46,7 +46,7 @@ version: "2"
 
 services:
   nginx-proxy:
-    image: jwilder/nginx-proxy
+    image: nginxproxy/nginx-proxy
     restart: always
     ports:
       - "80:80"
@@ -83,7 +83,7 @@ When this has finished, run `docker ps` . You should  see an output similar to t
 ```
 CONTAINER ID   IMAGE                           COMMAND                  CREATED         STATUS         PORTS                                                           NAMES
 8c8f2eac7c9a   portainer/portainer-ee:latest   "/portainer -H unix:…"   4 minutes ago   Up 4 minutes   9000/tcp, 0.0.0.0:8000->8000/tcp, :::8000->8000/tcp, 9443/tcp   portainer_portainer_1
-3e7c8b5d71d7   jwilder/nginx-proxy             "/app/docker-entrypo…"   4 minutes ago   Up 4 minutes   0.0.0.0:80->80/tcp, :::80->80/tcp                               portainer_nginx-proxy_1
+3e7c8b5d71d7   nginxproxy/nginx-proxy          "/app/docker-entrypo…"   4 minutes ago   Up 4 minutes   0.0.0.0:80->80/tcp, :::80->80/tcp                               portainer_nginx-proxy_1
 ```
 
 Once the deployment has finished you can browse `portainer.yourdomain.com`.
@@ -124,7 +124,7 @@ version: '3.2'
 
 services:
   nginx-proxy:
-    image: jwilder/nginx-proxy
+    image: nginxproxy/nginx-proxy
     networks:
       - proxy
     ports:
@@ -188,7 +188,7 @@ version: '3.2'
 
 services:
   nginx-proxy:
-    image: jwilder/nginx-proxy
+    image: nginxproxy/nginx-proxy
     networks:
       - proxy
     ports:
@@ -258,7 +258,7 @@ To check the deployment, run `docker service ls`. You should see an output simil
 ```
 ID                  NAME                    MODE                REPLICAS            IMAGE                          PORTS
 gy2bjxid0g4p        portainer_agent         global              1/1                 portainer/agent:latest
-jwvjp5bux4sz        portainer_nginx-proxy   replicated          1/1                 jwilder/nginx-proxy:latest     *:80->80/tcp
+jwvjp5bux4sz        portainer_nginx-proxy   replicated          1/1                 nginxproxy/nginx-proxy:latest  *:80->80/tcp
 5nflcvoxl3c7        portainer_portainer     replicated          1/1                 portainer/portainer-ee:latest  *:8000->8000/tcp
 ```
 


### PR DESCRIPTION
Hi, I'm the current maintainer of `jwilder/nginx-proxy`.

The `jwilder/nginx-proxy` project ownership was transferred to the [nginx-proxy GitHub org](https://github.com/nginx-proxy) on March of 2021.

The `jwilder/nginx-proxy` dockerhub image is considered legacy only, and while we still push updated images there, only the image under the up to date namespace `nginxproxy/nginx-proxy` should be used.