### PR TITLE
docs: fix mixed swarm urls

### DIFF
--- a/start/install/agent/README.md
+++ b/start/install/agent/README.md
@@ -6,8 +6,8 @@ If you want to add another environment to your existing Portainer installation, 
 [docker](docker/)
 {% endcontent-ref %}
 
-{% content-ref url="../server/swarm/" %}
-[swarm](../server/swarm/)
+{% content-ref url="swarm/" %}
+[swarm](swarm/)
 {% endcontent-ref %}
 
 {% content-ref url="kubernetes/" %}

--- a/start/install/agent/swarm/README.md
+++ b/start/install/agent/swarm/README.md
@@ -2,14 +2,14 @@
 
 Installation instructions can differ between platforms. Please choose your platform below:
 
-{% content-ref url="../../server/swarm/linux.md" %}
-[linux.md](../../server/swarm/linux.md)
+{% content-ref url="linux.md" %}
+[linux.md](linux.md)
 {% endcontent-ref %}
 
-{% content-ref url="../../server/swarm/wsl.md" %}
-[wsl.md](../../server/swarm/wsl.md)
+{% content-ref url="wsl.md" %}
+[wsl.md](wsl.md)
 {% endcontent-ref %}
 
-{% content-ref url="../../server/swarm/wcs.md" %}
-[wcs.md](../../server/swarm/wcs.md)
+{% content-ref url="wcs.md" %}
+[wcs.md](wcs.md)
 {% endcontent-ref %}

--- a/start/install/server/README.md
+++ b/start/install/server/README.md
@@ -6,8 +6,8 @@ Select the environment for your new Portainer installation:
 [docker](docker/)
 {% endcontent-ref %}
 
-{% content-ref url="../agent/swarm/" %}
-[swarm](../agent/swarm/)
+{% content-ref url="swarm/" %}
+[swarm](swarm/)
 {% endcontent-ref %}
 
 {% content-ref url="kubernetes/" %}

--- a/start/install/server/swarm/README.md
+++ b/start/install/server/swarm/README.md
@@ -2,14 +2,14 @@
 
 Installation instructions can differ between platforms. Please choose your platform below:
 
-{% content-ref url="../../agent/swarm/linux.md" %}
-[linux.md](../../agent/swarm/linux.md)
+{% content-ref url="linux.md" %}
+[linux.md](linux.md)
 {% endcontent-ref %}
 
-{% content-ref url="../../agent/swarm/wsl.md" %}
-[wsl.md](../../agent/swarm/wsl.md)
+{% content-ref url="wsl.md" %}
+[wsl.md](wsl.md)
 {% endcontent-ref %}
 
-{% content-ref url="../../agent/swarm/wcs.md" %}
-[wcs.md](../../agent/swarm/wcs.md)
+{% content-ref url="wcs.md" %}
+[wcs.md](wcs.md)
 {% endcontent-ref %}


### PR DESCRIPTION
As the name suggests, fixing mixed-up URLs related to Docker Swarm installation. Where links to server installation lead to agent installation, and vice-versa.