### PR TITLE
docs (reverse-proxy): Fix missing argument for creating a network with an `overlay` driver

### DIFF
--- a/advanced/reverse-proxy/nginx.md
+++ b/advanced/reverse-proxy/nginx.md
@@ -106,7 +106,7 @@ First, create two networks:
 ```
 
 ```
- docker network create -d agent_network
+ docker network create -d overlay agent_network
 ```
 
 Next, create the volume:


### PR DESCRIPTION
# Summary

Fix missing arguments for creating a network with an overlay driver.

```sh
❯  docker network create -d agent_network
"docker network create" requires exactly 1 argument.
See 'docker network create --help'.

Usage:  docker network create [OPTIONS] NETWORK
```

<details>
<summary>Show image</summary>

![2023-03-09T16-21-57_u5qy6R9C](https://user-images.githubusercontent.com/20911264/224086917-654ddf4d-5dd4-412d-8c57-adb1c7547d5a.png)
</details>
