### PR TITLE
Added info about edge-agent hostname requirement

### DIFF
--- a/advanced/edge-agent.md
+++ b/advanced/edge-agent.md
@@ -2,7 +2,8 @@
 
 ## The back story
 
-For standard deployments, we used to assume that the Portainer instance and any environments shared the same network and could communicate seamlessly. If remote environments were on a different network (say, across the Internet) we could not manage them.
+
+For standard deployments, we used to assume that the Portainer instance and any environments shared the same network and could communicate seamlessly. If remote environments were on a different network (say, across the Internet) we could not manage them.
 
 Then we changed the Edge agent architecture so only the environments need to access Portainer. There is now no need to expose the Portainer agents to the Internet.
 
@@ -14,13 +15,15 @@ If your Portainer instance is deployed with TLS, the agent will use HTTPS for th
 
 ## Creating an Edge Agent in Portainer
 
-When you create an Edge Agent, you are first asked for a human-friendly endpoint name. You are then asked to confirm the FQDN:PORT of your Portainer instance. This is what agents will use to connect, so make sure it’s correct and that the DNS resolves.
+
+When you create an Edge Agent, you are first asked for a human-friendly endpoint name. You are then asked to confirm the FQDN:PORT of your Portainer instance. This is what agents will use to connect, so make sure it’s correct and that the DNS resolves.
 
 During the creation process, an Edge ID is dynamically generated. This is a random UUID which is assigned to each environment. You can see it in the command syntax which is provided during the setup process.
 
 <figure><img src="../.gitbook/assets/2.15-advanced-edgeagent-command.png" alt=""><figcaption></figcaption></figure>
 
-The Edge ID and the join token are unique per environment. The join token is made up of the following encoded data:
+
+The Edge ID and the join token are unique per environment. The join token is made up of the following encoded data:
 
 * The Portainer instance API URL. This is how the Edge Agent knows how to ‘call home’ to your Portainer instance.
 * The Portainer instance reverse tunnel server address. This is identical to the API URL but with the SSH tunnel server port (`8000` is the default).
@@ -33,7 +36,9 @@ Use the command syntax to deploy an Edge Agent across your remote node or remote
 
 ### Polling
 
-Agents poll the Portainer instance every 5 seconds by default (this is defined in Portainer settings).
+
+
+Agents poll the Portainer instance every 5 seconds by default (this is defined in Portainer settings).
 
 ### Connection process and checks
 
@@ -48,6 +53,10 @@ Portainer encrypts the tunnel credentials using the Edge UUID as the encryption 
 ### Opening a tunnel between the agent and Portainer
 
 Once confirmation is received, the Edge Agent decrypts the credentials and opens a tunnel on port `8000` to the Portainer instance. If a remote environment is a swarm cluster, every node will run an instance of the agent (and every instance will poll Portainer). The 'you are required' flag causes the first agent in the cluster to establish the tunnel. Once in place, Portainer can then query the agent where the tunnel is open. If the tunnel closes for any reason, the agent will immediately re-establish it.
+
+{% hint style="warning" %}
+The hostname of the portainer API and tunnel must be the same. The Edge Agent connects to `https://portainer.example.org` for API access, and `ws://portainer.example.org:8000` for tunneling. Currently, having these two endpoints hosted on separate hostnames is not supported.
+{% endhint %}/
 
 ### When Portainer forces the Edge Agent to establish a tunnel
 


### PR DESCRIPTION
For Edge Agents to work, the Portainer API and tunnel endpoints must be hosted on the same hostname. I did not know this and wasted a few hours trying to figure out why the agent couldn't connect to `portainer.example.org` for API access and `edge.example.org` for tunneling.

(The `^M` diffs appeared because I edited the file in the GitHub UI. LMK if I should try and clean up the diff)