### PR TITLE
Add missing port mapping for Docker examples

### DIFF
--- a/advanced/reverse-proxy/nginx.md
+++ b/advanced/reverse-proxy/nginx.md
@@ -30,6 +30,7 @@ services:
       - VIRTUAL_HOST=portainer.yourdomain.com
       - VIRTUAL_PORT=9000
     ports:
+      - 9000:9000
       - 8000:8000
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
@@ -61,6 +62,7 @@ services:
       - VIRTUAL_HOST=portainer.yourdomain.com
       - VIRTUAL_PORT=9000
     ports:
+      - 9000:9000
       - 8000:8000
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
@@ -160,6 +162,7 @@ services:
       - VIRTUAL_HOST=portainer.yourdomain.com
       - VIRTUAL_PORT=9000
     ports:
+      - 9000:9000
       - 8000:8000
     networks:
       - proxy
@@ -224,6 +227,7 @@ services:
       - VIRTUAL_HOST=portainer.yourdomain.com
       - VIRTUAL_PORT=9000
     ports:
+      - 9000:9000
       - 8000:8000
     networks:
       - proxy


### PR DESCRIPTION
The examples show the port mapping for 8000:8000 for portainer but the actual forwarded port is 9000. This commit add the 9000:9000 mapping. I did not touch the 8000:8000 mapping since it seems important without being documented anywhere. This could also simply be a matter of needing to change "8000" instances by  "9000"