### PR TITLE
docs(api): Fix URL to SwaggerHub for 2.21.0 CE

### DIFF
--- a/api/docs.md
+++ b/api/docs.md
@@ -9,7 +9,7 @@ You will need an access token in order to use the Portainer API. If you have not
 You can find our API documentation at SwaggerHub:
 
 * [Business Edition (BE) 2.21.0 API Documentation](https://app.swaggerhub.com/apis/portainer/portainer-ee/2.21.0)
-* [Community Edition (CE) 2.21.0 API Documentation](https://app.swaggerhub.com/apis/portainer/portainer-ce/2.21.o)
+* [Community Edition (CE) 2.21.0 API Documentation](https://app.swaggerhub.com/apis/portainer/portainer-ce/2.21.0)
 
 We have also provided some examples of API usage.
 


### PR DESCRIPTION
Fix the SwaggerHub URL for 2.21.0 CE API Docs