### PR TITLE
Update linux.md to pull latest LTS

### DIFF
--- a/start/install/server/docker/linux.md
+++ b/start/install/server/docker/linux.md
@@ -36,7 +36,7 @@ docker volume create portainer_data
 
 Then, download and install the Portainer Server container:
 
-<pre><code><strong>docker run -d -p 8000:8000 -p 9443:9443 --name portainer --restart=always -v /var/run/docker.sock:/var/run/docker.sock -v portainer_data:/data portainer/portainer-ee:2.21.4
+<pre><code><strong>docker run -d -p 8000:8000 -p 9443:9443 --name portainer --restart=always -v /var/run/docker.sock:/var/run/docker.sock -v portainer_data:/data portainer/portainer-ee:lts
 </strong></code></pre>
 
 {% hint style="info" %}


### PR DESCRIPTION
Pull the latest LTS by default since the tag exist. This avoid the need to update the portainer instance just after installing it