### PR TITLE
swarmMode doesn't exist anymore

### DIFF
--- a/advanced/reverse-proxy/traefik.md
+++ b/advanced/reverse-proxy/traefik.md
@@ -278,6 +278,7 @@ services:
       - --entrypoints.web.address=:80
       - --entrypoints.websecure.address=:443
       - --providers.docker=true
+      - --providers.swarm=true
       - --providers.docker.exposedbydefault=false
       - --providers.docker.network=public
       - --api

--- a/advanced/reverse-proxy/traefik.md
+++ b/advanced/reverse-proxy/traefik.md
@@ -278,7 +278,6 @@ services:
       - --entrypoints.web.address=:80
       - --entrypoints.websecure.address=:443
       - --providers.docker=true
-      - --providers.docker.swarmMode=true
       - --providers.docker.exposedbydefault=false
       - --providers.docker.network=public
       - --api


### PR DESCRIPTION
In more recent traefik versions (3 and onwards), this option doesn't existe anymore and deploying with it gets the following error:

```json
traefik-ingress_traefik.1.xqof6xltm6he@docker-swarm-manager    | {"level":"error","loader":"FLAG","time":"2025-03-27T09:46:41Z","message":"Docker provider `swarmMode` option has been removed in v3, please use the Swarm Provider instead.For more information please read the migration guide: https://doc.traefik.io/traefik/v3.3/migration/v2-to-v3/#docker-docker-swarm"}
```