### PR TITLE
Typo: Change Edge Agent Docker image from 'lts' to 'sts'

### DIFF
--- a/start/upgrade/edge.md
+++ b/start/upgrade/edge.md
@@ -44,7 +44,7 @@ docker pull portainer/agent:sts
 To deploy the updated Edge Agent, replace the `your-edge-identifier-here` and `your-edge-key-here` values in the following command with those you retrieved earlier, then run the command:
 
 ```
-docker run -d -v /var/run/docker.sock:/var/run/docker.sock -v /var/lib/docker/volumes:/var/lib/docker/volumes -v /:/host -v portainer_agent_data:/data --restart always -e EDGE=1 -e EDGE_ID=your-edge-identifier-here -e EDGE_KEY=your-edge-key-here -e EDGE_INSECURE_POLL=1 --name portainer_edge_agent portainer/agent:lts
+docker run -d -v /var/run/docker.sock:/var/run/docker.sock -v /var/lib/docker/volumes:/var/lib/docker/volumes -v /:/host -v portainer_agent_data:/data --restart always -e EDGE=1 -e EDGE_ID=your-edge-identifier-here -e EDGE_KEY=your-edge-key-here -e EDGE_INSECURE_POLL=1 --name portainer_edge_agent portainer/agent:sts
 ```
 
 ## Docker Swarm


### PR DESCRIPTION
The documentation had the reader pull the `sts` image, but run the `lts` image. Updated to be consistent.