### PR TITLE
fix: correct Kubernetes version typo and image tag in docker ps examples

### DIFF
--- a/start/install-ce/server/docker/linux.md
+++ b/start/install-ce/server/docker/linux.md
@@ -61,7 +61,7 @@ Portainer Server has now been installed. You can check to see whether the Portai
 ```bash
 root@server:~# docker ps
 CONTAINER ID   IMAGE                        COMMAND        CREATED         STATUS         PORTS                                                                                                NAMES
-7963585688a9   portainer/portainer-ce:sts   "/portainer"   8 seconds ago   Up 8 seconds   0.0.0.0:8000->8000/tcp, [::]:8000->8000/tcp, 0.0.0.0:9443->9443/tcp, [::]:9443->9443/tcp, 9000/tcp   portainer
+7963585688a9   portainer/portainer-ce:lts   "/portainer"   8 seconds ago   Up 8 seconds   0.0.0.0:8000->8000/tcp, [::]:8000->8000/tcp, 0.0.0.0:9443->9443/tcp, [::]:9443->9443/tcp, 9000/tcp   portainer
 ```
 {% endtab %}
 
@@ -107,7 +107,7 @@ Docker Compose will create the necessary resources and deploy Portainer. You can
 ```
 root@server:~# docker ps
 CONTAINER ID   IMAGE                        COMMAND        CREATED         STATUS         PORTS                                                                                                NAMES
-7963585688a9   portainer/portainer-ce:sts   "/portainer"   8 seconds ago   Up 8 seconds   0.0.0.0:8000->8000/tcp, [::]:8000->8000/tcp, 0.0.0.0:9443->9443/tcp, [::]:9443->9443/tcp, 9000/tcp   portainer
+7963585688a9   portainer/portainer-ce:lts   "/portainer"   8 seconds ago   Up 8 seconds   0.0.0.0:8000->8000/tcp, [::]:8000->8000/tcp, 0.0.0.0:9443->9443/tcp, [::]:9443->9443/tcp, 9000/tcp   portainer
 ```
 {% endtab %}
 {% endtabs %}

--- a/start/install/server/docker/linux.md
+++ b/start/install/server/docker/linux.md
@@ -61,7 +61,7 @@ Portainer Server has now been installed. You can check to see whether the Portai
 ```bash
 root@server:~# docker ps
 CONTAINER ID   IMAGE                        COMMAND        CREATED         STATUS         PORTS                                                                                                NAMES
-7963585688a9   portainer/portainer-ee:sts   "/portainer"   8 seconds ago   Up 8 seconds   0.0.0.0:8000->8000/tcp, [::]:8000->8000/tcp, 0.0.0.0:9443->9443/tcp, [::]:9443->9443/tcp, 9000/tcp   portainer
+7963585688a9   portainer/portainer-ee:lts   "/portainer"   8 seconds ago   Up 8 seconds   0.0.0.0:8000->8000/tcp, [::]:8000->8000/tcp, 0.0.0.0:9443->9443/tcp, [::]:9443->9443/tcp, 9000/tcp   portainer
 ```
 {% endtab %}
 
@@ -107,7 +107,7 @@ Docker Compose will create the necessary resources and deploy Portainer. You can
 ```
 root@server:~# docker ps
 CONTAINER ID   IMAGE                        COMMAND        CREATED         STATUS         PORTS                                                                                                NAMES
-7963585688a9   portainer/portainer-ee:sts   "/portainer"   8 seconds ago   Up 8 seconds   0.0.0.0:8000->8000/tcp, [::]:8000->8000/tcp, 0.0.0.0:9443->9443/tcp, [::]:9443->9443/tcp, 9000/tcp   portainer
+7963585688a9   portainer/portainer-ee:lts   "/portainer"   8 seconds ago   Up 8 seconds   0.0.0.0:8000->8000/tcp, [::]:8000->8000/tcp, 0.0.0.0:9443->9443/tcp, [::]:9443->9443/tcp, 9000/tcp   portainer
 ```
 {% endtab %}
 {% endtabs %}

--- a/start/requirements-and-prerequisites.md
+++ b/start/requirements-and-prerequisites.md
@@ -57,7 +57,7 @@ The following tables list all of the configurations that we have tested, validat
 | Community 2.33.2 LTS | September 25, 2025 | 27.5.1 28.4.0  | 1.31 1.32 1.33     | 5.6.0          | [ARM64](https://portal.portainer.io/knowledge/which-arm-architectures-does-portainer-support), x86\_64 |
 | Community 2.34.0 STS | September 18, 2025 | 27.5.1 28.3.3  | 1.31 1.32 1.33     | 5.5.1          | [ARM64](https://portal.portainer.io/knowledge/which-arm-architectures-does-portainer-support), x86\_64 |
 | Community 2.33.1 LTS | August 27, 2025    | 27.5.1 28.3.2  | 1.31 1.32 1.33     | 5.5.1          | [ARM64](https://portal.portainer.io/knowledge/which-arm-architectures-does-portainer-support), x86\_64 |
-| Community 2.33.0 LTS | August 20, 2025    | 27.5.1 28.3.2  | 1.31 1.32 .133     | 5.5.1          | [ARM64](https://portal.portainer.io/knowledge/which-arm-architectures-does-portainer-support), x86\_64 |
+| Community 2.33.0 LTS | August 20, 2025    | 27.5.1 28.3.2  | 1.31 1.32 1.33     | 5.5.1          | [ARM64](https://portal.portainer.io/knowledge/which-arm-architectures-does-portainer-support), x86\_64 |
 
 {% hint style="info" %}
 If you find an issue with an unlisted configuration, before reporting a bug, update your environment to a valid configuration and try to replicate the issue.


### PR DESCRIPTION
## Summary

Two small doc fixes found while reading the installation guides:

**1. Kubernetes version typo in requirements-and-prerequisites.md**

The CE 2.33.0 LTS row has `.133` instead of `1.33` in the Kubernetes Version column:

```
Before: | 1.31 1.32 .133 |
After:  | 1.31 1.32 1.33 |
```

**2. Image tag inconsistency in docker ps examples (CE and BE linux.md)**

The install commands use `portainer-ce:lts` / `portainer-ee:lts`, but the `docker ps` output examples right below them showed `:sts`. Updated both to show `:lts` to match the preceding install command, avoiding confusion for users following the guide.